### PR TITLE
Use proper Country Codes

### DIFF
--- a/mangopay/mangopay.cabal
+++ b/mangopay/mangopay.cabal
@@ -1,5 +1,5 @@
 name:           mangopay
-version:        1.4
+version:        1.5
 cabal-version:  >= 1.8
 build-type:     Simple
 author:         JP Moresmau <jpmoresmau@gmail.com>
@@ -53,6 +53,8 @@ library
      , monad-logger                  >= 0.3        && < 0.4
      , vector >=0.10.9 && <0.11
      , template-haskell
+     , iso3166-country-codes
+
   if flag(conduit11)
     build-depends:
          conduit              == 1.1.*
@@ -102,7 +104,7 @@ test-suite mangopay-tests
      data-default, http-conduit, http-types, lifted-base,
      monad-control, monad-logger, resourcet, template-haskell,
      text, time, transformers, transformers-base,
-     unordered-containers, utf8-string, vector
+     unordered-containers, utf8-string, vector, iso3166-country-codes
 
      , blaze-builder
      , HTF            >  0.9

--- a/mangopay/src/Web/MangoPay/Accounts.hs
+++ b/mangopay/src/Web/MangoPay/Accounts.hs
@@ -14,6 +14,8 @@ import Data.Time.Clock.POSIX (POSIXTime)
 import Control.Applicative
 import qualified Network.HTTP.Types as HT
 
+import Data.ISO3166_CountryCodes (CountryCode)
+
 -- | create an account
 storeAccount ::  (MPUsableMonad m) => BankAccount -> AccessToken -> MangoPayT m BankAccount
 storeAccount ba at
@@ -54,7 +56,7 @@ data BankAccountDetails=IBAN {
   } | Other {
   atAccountNumber :: Text
   ,atBIC :: Text
-  ,atCountry :: Text
+  ,atCountry :: CountryCode
   } deriving (Show,Read,Eq,Ord,Typeable)
   
 -- | from json as per MangoPay format 

--- a/mangopay/src/Web/MangoPay/Types.hs
+++ b/mangopay/src/Web/MangoPay/Types.hs
@@ -31,6 +31,8 @@ import Language.Haskell.TH.Syntax (qLocation)
 import Text.Printf (printf)
 import qualified Data.ByteString.Lazy as BS (toStrict)
 
+import Data.ISO3166_CountryCodes (CountryCode)
+
 -- | the MangoPay access point
 data AccessPoint = Sandbox | Production | Custom ByteString
         deriving (Show,Read,Eq,Ord,Typeable)
@@ -127,6 +129,7 @@ instance FromJSON MpError where
                          v .: "Date"
     parseJSON _= fail "MpError"
 
+-- | from json as per MangoPay format
 instance FromJSON POSIXTime where
     parseJSON n@(Number _)=(fromIntegral . (round::Double -> Integer)) <$> parseJSON n
     parseJSON _ = fail "POSIXTime"
@@ -134,6 +137,17 @@ instance FromJSON POSIXTime where
 -- | to json as per MangoPay format
 instance ToJSON POSIXTime  where
     toJSON pt=toJSON (round pt :: Integer)
+
+-- | to json as per MangoPay format
+instance ToJSON CountryCode where
+        toJSON =toJSON . show
+
+-- | from json as per MangoPay format
+instance FromJSON CountryCode where
+  parseJSON (String s)
+    | ((a,_):_)<-reads $ unpack s=pure a
+  parseJSON _ =fail "CountryCode"
+
 
 -- | Pagination info for searches
 -- <http://docs.mangopay.com/api-references/pagination/>

--- a/mangopay/src/Web/MangoPay/Users.hs
+++ b/mangopay/src/Web/MangoPay/Users.hs
@@ -5,12 +5,14 @@ module Web.MangoPay.Users where
 import Web.MangoPay.Monad
 import Web.MangoPay.Types
 
+import Data.ISO3166_CountryCodes (CountryCode)
 import Data.Text
 import Data.Typeable (Typeable)
 import Data.Aeson
 import Data.Time.Clock.POSIX (POSIXTime)
 import Control.Applicative
 import qualified Network.HTTP.Types as HT
+
 
 -- | create or edit a natural user
 storeNaturalUser ::  (MPUsableMonad m) => NaturalUser -> AccessToken -> MangoPayT m NaturalUser
@@ -127,8 +129,8 @@ data NaturalUser=NaturalUser {
         ,uLastName :: Text -- ^  User’s lastname
         ,uAddress :: Maybe Text -- ^  User’s address
         ,uBirthday :: POSIXTime -- ^   User’s birthdate
-        ,uNationality :: Text -- ^ User’s Nationality
-        ,uCountryOfResidence:: Text -- ^User’s country of residence
+        ,uNationality :: CountryCode -- ^ User’s Nationality
+        ,uCountryOfResidence:: CountryCode -- ^User’s country of residence
         ,uOccupation :: Maybe Text -- ^User’s occupation (ie. Work)
         ,uIncomeRange :: Maybe IncomeRange -- ^ User’s income range
         ,uTag :: Maybe Text -- ^  Custom data
@@ -194,8 +196,8 @@ data LegalUser=LegalUser {
         ,lLegalRepresentativeAddress :: Maybe Text -- ^ The address of the company’s Legal representative person
         ,lLegalRepresentativeEmail :: Maybe Text -- ^  The email of the company’s Legal representative person
         ,lLegalRepresentativeBirthday :: POSIXTime -- ^ The birthdate of the company’s Legal representative person
-        ,lLegalRepresentativeNationality :: Text -- ^ the nationality of the company’s Legal representative person
-        ,lLegalRepresentativeCountryOfResidence :: Text -- ^  The country of residence of the company’s Legal representative person
+        ,lLegalRepresentativeNationality :: CountryCode -- ^ the nationality of the company’s Legal representative person
+        ,lLegalRepresentativeCountryOfResidence :: CountryCode -- ^  The country of residence of the company’s Legal representative person
         ,lStatute  :: Maybe Text -- ^  The business statute of the company
         ,lTag   :: Maybe Text -- ^  Custom data
         ,lProofOfRegistration :: Maybe Text -- ^   The proof of registration of the company

--- a/mangopay/test/Web/MangoPay/UsersTest.hs
+++ b/mangopay/test/Web/MangoPay/UsersTest.hs
@@ -9,8 +9,10 @@ import Test.Framework
 import Test.HUnit (Assertion)
 import Data.Maybe (fromJust, isJust)
 
+import Data.ISO3166_CountryCodes (CountryCode(FR))
+
 testNaturalUser :: NaturalUser
-testNaturalUser=NaturalUser Nothing Nothing "jpmoresmau@gmail.com" "JP" "Moresmau" Nothing 11111 "FR" "FR" 
+testNaturalUser=NaturalUser Nothing Nothing "jpmoresmau@gmail.com" "JP" "Moresmau" Nothing 11111 FR FR 
         (Just "Haskell contractor") (Just IncomeRange2) Nothing Nothing Nothing 
 
 test_NaturalUser :: Assertion
@@ -31,7 +33,7 @@ test_NaturalUser = do
 
 testLegalUser :: LegalUser
 testLegalUser = LegalUser Nothing Nothing "jpmoresmau@gmail.com" "JP Moresmau" Business Nothing
-        "JP" "Moresmau" (Just "my house") Nothing 222222 "FR" "FR" Nothing Nothing Nothing Nothing
+        "JP" "Moresmau" (Just "my house") Nothing 222222 FR FR Nothing Nothing Nothing Nothing
         
 test_LegalUser :: Assertion
 test_LegalUser = do

--- a/yesod-mangopay/app/Base/Util.hs
+++ b/yesod-mangopay/app/Base/Util.hs
@@ -14,6 +14,8 @@ import Data.Text.Read (decimal)
 
 import Web.MangoPay
 
+import Data.ISO3166_CountryCodes (CountryCode, readableCountryName)
+
 -- | localized field
 localizedFS :: forall master msg.
             RenderMessage master msg =>
@@ -66,3 +68,8 @@ getPaginationNav (Just (Pagination i _)) l=let
     in (previous,next)
 getPaginationNav _ _= (Nothing,Nothing)             
     
+    
+-- | country field
+countryField :: RenderMessage site FormMessage =>
+                  Field (HandlerT site IO) CountryCode
+countryField = selectFieldList $ map (pack . readableCountryName &&& id) [minBound..maxBound] 

--- a/yesod-mangopay/app/Handler/User.hs
+++ b/yesod-mangopay/app/Handler/User.hs
@@ -114,8 +114,8 @@ naturalUserForm muser= renderDivs $ NaturalUser
         { jdsChangeYear = True -- give a year dropdown
         , jdsYearRange = "1900:-5" -- 1900 till five years ago
         }) (localizedFS MsgUserBirthday) (posix2Day <$> uBirthday <$> muser))
-    <*> areq textField (localizedFS MsgUserNationality)  (uNationality <$> muser)
-    <*> areq textField (localizedFS MsgUserCountry) (uCountryOfResidence <$> muser)
+    <*> areq countryField (localizedFS MsgUserNationality)  (uNationality <$> muser)
+    <*> areq countryField (localizedFS MsgUserCountry) (uCountryOfResidence <$> muser)
     <*> aopt textField (localizedFS MsgUserOccupation) (uOccupation <$> muser)
     <*> aopt (selectFieldList ranges) (localizedFS MsgUserIncome) (uIncomeRange <$> muser)
     <*> aopt textField (localizedFS MsgUserCustomData) (uTag <$> muser)
@@ -140,8 +140,8 @@ legalUserForm muser= renderDivs $ LegalUser
         { jdsChangeYear = True -- give a year dropdown
         , jdsYearRange = "1900:-5" -- 1900 till five years ago
         }) (localizedFS MsgUserRepBirthday) (posix2Day <$> lLegalRepresentativeBirthday <$> muser))   
-    <*> areq textField (localizedFS MsgUserRepNationality) (lLegalRepresentativeNationality <$> muser)  
-    <*> areq textField (localizedFS MsgUserRepCountry) (lLegalRepresentativeCountryOfResidence <$> muser)
+    <*> areq countryField (localizedFS MsgUserRepNationality) (lLegalRepresentativeNationality <$> muser)  
+    <*> areq countryField (localizedFS MsgUserRepCountry) (lLegalRepresentativeCountryOfResidence <$> muser)
     <*> pure Nothing  -- value comes from Documents uploaded (I think)
     <*> aopt textField (localizedFS MsgUserCustomData) (lTag <$> muser)  
     <*> pure Nothing  -- value comes from Documents uploaded

--- a/yesod-mangopay/yesod-mangopay.cabal
+++ b/yesod-mangopay/yesod-mangopay.cabal
@@ -1,5 +1,5 @@
 name:           yesod-mangopay
-version:        1.4
+version:        1.5
 cabal-version:  >= 1.8
 build-type:     Simple
 author:         JP Moresmau <jpmoresmau@gmail.com>
@@ -37,7 +37,7 @@ library
     hs-source-dirs:    src
     build-depends:
                    base         >= 4      && < 5
-                 , mangopay     == 1.4.*
+                 , mangopay     == 1.5.*
                  , containers   >= 0.5    && < 0.6
                  , http-conduit >= 2.0    && < 2.2
                  , http-types   >= 0.8.2  && < 0.9
@@ -120,8 +120,9 @@ executable         yesod-mangopay
                  , yesod-auth                    >= 1.2.6
                  , yesod-form                    >= 1.3.0      && < 1.4
                  , yesod-persistent
-                 , yesod-static                  >= 1.2        && < 1.3,
-                 lifted-base >=0.2.2 && <0.3
+                 , yesod-static                  >= 1.2        && < 1.3
+                 , lifted-base                   >=0.2.2 && <0.3
+                 , iso3166-country-codes
     if flag(conduit11)
       build-depends:
           conduit       == 1.1.*


### PR DESCRIPTION
While working on the site for the user forms, I realized there was a Haskell package giving us the proper codes for the ISO standard MangoPay uses, so this gives us
1. more safety (it's a mangopay error to not provide a correct country code)
2. better UI with the list of known countries

I'll upload to Hackage soon unless you have an issue with that change!
