### PR TITLE
Fix aeson dependency lower bound.

### DIFF
--- a/mangopay/mangopay.cabal
+++ b/mangopay/mangopay.cabal
@@ -41,7 +41,7 @@ library
      , http-types
      , http-conduit         >= 2.0  && < 2.2
      , attoparsec           >= 0.10 && < 0.12
-     , aeson                >= 0.5  && < 0.8
+     , aeson                >= 0.7  && < 0.8
      , time
      , data-default
      , lifted-base


### PR DESCRIPTION
Otherwise for aeson < 0.7:

```
src/Web/MangoPay/Types.hs:23:27:
    Module ‘Data.Aeson.Encode’ does not export ‘encodeToTextBuilder’
```
